### PR TITLE
Support array of non db attrs for metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_revisionable (1.2.2.sermo)
+    acts_as_revisionable (1.2.3.sermo)
       activerecord (~> 3.2)
 
 GEM

--- a/lib/acts_as_revisionable.rb
+++ b/lib/acts_as_revisionable.rb
@@ -305,7 +305,7 @@ module ActsAsRevisionable
         end
       elsif meta_options.is_a?(Array)
         meta_options.each do |attribute|
-          set_revision_meta_attribute(revision, attribute, attribute.to_sym)
+          set_revision_meta_attributes(attribute, revision, base_record)
         end
       elsif meta_options
         value = base_record.send(meta_options)

--- a/lib/acts_as_revisionable/version.rb
+++ b/lib/acts_as_revisionable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsRevisionable
-  VERSION = '1.2.2.sermo'
+  VERSION = '1.2.3.sermo'
 end


### PR DESCRIPTION
This version bumps.

Also:
The previous implementation only pulled the attribute from the invoking model if there was one attribute (:meta => :foo)

This changes allow specifying an array of attributes that aren't database backed.  (:meta => [:foo, :bar])
