### PR TITLE
Add before_set_revision callback to options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_revisionable (1.2.3.sermo)
+    acts_as_revisionable (1.3.0.sermo)
       activerecord (~> 3.2)
 
 GEM

--- a/lib/acts_as_revisionable/version.rb
+++ b/lib/acts_as_revisionable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsRevisionable
-  VERSION = '1.2.3.sermo'
+  VERSION = '1.3.0.sermo'
 end


### PR DESCRIPTION
Instead of doing the 'munge' of passing objects around and trying to get
information off it, this allows an information setting callback.

The use case is attributes that are not database backed, but are wanted
on the version.  If the methods provided to 'meta' don't do something
dynamic, the value would get set. Say, something like 'updated_by'.

The previous implementation tried to solve this, but didn't work for
more than one attribute in 'meta'.

The current solution allows a user to set :before_store_revision =>
:my_callback and then call
  object.store_revision(some_args) do
    ...
  end

object#my_callback will trigger before the versioning starts:
  revisioned_object.send(:my_callback, *some_args)

revisioned_object is _not_ the object you are calling 'store_revision'
on. It is the read-only copy that the revision tree is built from.
