### PR TITLE
Rails 5.2 compatibility

### DIFF
--- a/lib/acts_as_revisionable.rb
+++ b/lib/acts_as_revisionable.rb
@@ -251,7 +251,7 @@ module ActsAsRevisionable
     # Build a revision record based on this record
     def build_revision
       revision_options = self.class.acts_as_revisionable_options
-      revision = revision_record_class.new(self, revision_options[:encoding])
+      revision = revision_record_class.new(self)
       set_revision_meta_attributes(revision_options[:meta], revision)
 
       revision

--- a/lib/acts_as_revisionable/revision_record.rb
+++ b/lib/acts_as_revisionable/revision_record.rb
@@ -62,9 +62,10 @@ module ActsAsRevisionable
 
     # Create a revision record based on a record passed in. The attributes of the original record will
     # be serialized. If it uses the acts_as_revisionable behavior, associations will be revisioned as well.
-    def initialize(record, encoding = :ruby)
+    def initialize(record)
       super({})
-      @data_encoding = encoding
+      options = record.class.try(:acts_as_revisionable_options) || {}
+      @data_encoding = options[:encoding] || :ruby
       self.revisionable_type = record.class.base_class.name
       self.revisionable_id = record.id
       associations = record.class.revisionable_associations if record.class.respond_to?(:revisionable_associations)

--- a/spec/revision_record_spec.rb
+++ b/spec/revision_record_spec.rb
@@ -219,7 +219,8 @@ describe ActsAsRevisionable::RevisionRecord do
 
   it "should be able to restore the original model using Ruby serialization" do
     attributes = {'id' => 1, 'name' => 'revision', 'value' => 5, 'test_revisionable_one_association_record_id' => nil}
-    revision = ActsAsRevisionable::RevisionRecord.new(TestRevisionableRecord.new(attributes), :ruby)
+    TestRevisionableRecord.acts_as_revisionable_options[:encoding] = :ruby
+    revision = ActsAsRevisionable::RevisionRecord.new(TestRevisionableRecord.new(attributes))
     revision.data = Zlib::Deflate.deflate(Marshal.dump(attributes))
     restored = revision.restore
     restored.class.should == TestRevisionableRecord
@@ -229,7 +230,8 @@ describe ActsAsRevisionable::RevisionRecord do
 
   it "should be able to restore the original model using YAML serialization" do
     attributes = {'id' => 1, 'name' => 'revision', 'value' => 5, 'test_revisionable_one_association_record_id' => nil}
-    revision = ActsAsRevisionable::RevisionRecord.new(TestRevisionableRecord.new(attributes), :yaml)
+    TestRevisionableRecord.acts_as_revisionable_options[:encoding] = :yaml
+    revision = ActsAsRevisionable::RevisionRecord.new(TestRevisionableRecord.new(attributes))
     revision.data = Zlib::Deflate.deflate(YAML.dump(attributes))
     restored = revision.restore
     restored.class.should == TestRevisionableRecord
@@ -239,7 +241,8 @@ describe ActsAsRevisionable::RevisionRecord do
 
   it "should be able to restore the original model using XML serialization" do
     attributes = {'id' => 1, 'name' => 'revision', 'value' => 5, 'test_revisionable_one_association_record_id' => nil}
-    revision = ActsAsRevisionable::RevisionRecord.new(TestRevisionableRecord.new(attributes), :xml)
+    TestRevisionableRecord.acts_as_revisionable_options[:encoding] = :xml
+    revision = ActsAsRevisionable::RevisionRecord.new(TestRevisionableRecord.new(attributes))
     revision.data = Zlib::Deflate.deflate(YAML.dump(attributes))
     restored = revision.restore
     restored.class.should == TestRevisionableRecord


### PR DESCRIPTION
Rails 5.2 AR records initializers don't like to have extra method arguments. This patch brings acts_as_revisionable back into parity.